### PR TITLE
[SCB-1660] change deploy.sh format

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -17,16 +17,9 @@
 ## ---------------------------------------------------------------------------
 #bin/sh
 
-TAGGEDCOMMIT=$(git tag -l --contains HEAD)
-if [ "$TAGGEDCOMMIT" == "" ]; then
-  TAGGEDCOMMIT=false
-else
-  TAGGEDCOMMIT=true
-fi
-echo "${green}[SCRIPT] TAGGEDCOMMIT=$TAGGEDCOMMIT${reset}"
 VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-if [[ "$TAGGEDCOMMIT" == "true" ]] || [[ ! $VERSION =~ "SNAPSHOT" ]]; then
-  echo "${green}[SCRIPT] Skipping the Non-Signed Staging deploy as it is tagged commit.${reset}"
+if [[ ! $VERSION =~ "SNAPSHOT" ]]; then
+  echo "${green}[SCRIPT] Not Snapshot Version,Skipping Deployment.${reset}"
 else
   echo "Deploy a Non-Signed Staging Release"
   mvn deploy -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -B -DskipTests --settings .travis.settings.xml


### PR DESCRIPTION
scripts/deploy.sh, now the format is dos, will execute fail in Linux
I change format to unix and skip the version that is not snapshot