### PR TITLE
[SCB-1659] Upgrade maven-assembly-plugin to 3.2.0

### DIFF
--- a/oas-generator/oas-generator-servicecomb/pom.xml
+++ b/oas-generator/oas-generator-servicecomb/pom.xml
@@ -59,6 +59,26 @@
           <groupId>io.zipkin.brave</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.vertx</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.servicecomb</groupId>
+          <artifactId>foundation-vertx</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.servicecomb</groupId>
+          <artifactId>foundation-ssl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.servicecomb</groupId>
+          <artifactId>foundation-config</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.servicecomb</groupId>
+          <artifactId>deployment</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     

--- a/toolkit-distribution/pom.xml
+++ b/toolkit-distribution/pom.xml
@@ -133,6 +133,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-assembly-plugin</artifactId>
+            <version>3.2.0</version>
             <executions>
               <execution>
                 <id>src</id>


### PR DESCRIPTION
Upgrade maven-assembly-plugin to 3.2.0 and exclude some unused artifacts. 
Now It can correctly exclude transitive dependencies.

-------------------------------------------------------------------------
I have run the command below to generate the binary package
``` 
mvn clean install -Prelease -Dgpg.skip=true
```

and all jars in `apache-servicecomb-toolkit-distribution-0.2.0-bin.zip/apache-servicecomb-toolkit-distribution-0.2.0-bin/libs` is shown below:
```
cli-0.2.0.jar
airline-0.7.jar
javax.inject-1.jar
guava-18.0.jar
log4j-slf4j-impl-2.3.jar
slf4j-api-1.7.26.jar
log4j-api-2.3.jar
log4j-core-2.3.jar
codegen-0.2.0.jar
swagger-codegen-2.4.3.jar
swagger-parser-1.0.43.jar
swagger-compat-spec-parser-1.0.43.jar
json-schema-validator-2.2.8.jar
json-schema-core-1.2.8.jar
rhino-1.7R4.jar
uri-template-0.9.jar
mailapi-1.4.3.jar
activation-1.1.jar
libphonenumber-8.0.0.jar
jsr305-3.0.1.jar
jopt-simple-5.0.3.jar
json-patch-1.6.jar
jackson-coreutils-1.6.jar
msg-simple-1.1.jar
btf-1.2.jar
httpclient-4.5.8.jar
httpcore-4.4.11.jar
commons-codec-1.11.jar
swagger-core-1.5.22.jar
swagger-models-1.5.22.jar
swagger-annotations-1.5.22.jar
jmustache-1.14.jar
commons-io-2.6.jar
slf4j-ext-1.7.26.jar
commons-cli-1.2.jar
commonmark-0.9.0.jar
log4j-jcl-2.3.jar
commons-logging-1.2.jar
contractgen-0.2.0.jar
common-0.2.0.jar
org.eclipse.jgit-5.3.0.201903130848-r.jar
jsch-0.1.54.jar
jzlib-1.1.1.jar
JavaEWAH-1.1.6.jar
core-0.2.0.jar
openapi-generator-4.1.2.jar
swagger-parser-2.0.14-OpenAPITools.org-1.jar
swagger-parser-v2-converter-2.0.14-OpenAPITools.org-1.jar
swagger-parser-core-2.0.14-OpenAPITools.org-1.jar
swagger-parser-v3-2.0.14-OpenAPITools.org-1.jar
handlebars-4.1.2.jar
handlebars-jackson2-4.1.2.jar
jackson-datatype-guava-2.9.8.jar
jackson-core-2.9.8.jar
generex-1.0.2.jar
automaton-1.11-8.jar
jackson-datatype-jsr310-2.9.8.jar
jackson-datatype-joda-2.9.8.jar
joda-time-2.10.1.jar
jackson-datatype-threetenbp-2.6.4.jar
threetenbp-1.3.1.jar
openapi-generator-core-4.1.2.jar
docgen-0.2.0.jar
swagger-generator-core-1.2.0.jar
foundation-common-1.2.0.jar
jackson-dataformat-xml-2.9.8.jar
jackson-module-jaxb-annotations-2.9.8.jar
stax2-api-3.1.4.jar
woodstox-core-5.0.3.jar
log4j-1.2.17.jar
common-javassist-1.2.0.jar
javassist-3.18.1-GA.jar
javax.servlet-api-4.0.1.jar
guice-4.1.0.jar
aopalliance-1.0.jar
commons-lang3-3.4.jar
oas-validator-core-0.2.0.jar
commons-collections4-4.3.jar
swagger-parser-2.0.15.jar
swagger-parser-v2-converter-2.0.15.jar
swagger-parser-core-2.0.15.jar
swagger-parser-v3-2.0.15.jar
oas-validator-core-spring-0.2.0.jar
spring-boot-starter-2.1.4.RELEASE.jar
spring-boot-2.1.4.RELEASE.jar
spring-boot-autoconfigure-2.1.4.RELEASE.jar
spring-boot-starter-logging-2.1.4.RELEASE.jar
logback-classic-1.2.3.jar
logback-core-1.2.3.jar
log4j-to-slf4j-2.11.2.jar
jul-to-slf4j-1.7.26.jar
javax.annotation-api-1.3.2.jar
spring-core-5.1.6.RELEASE.jar
spring-jcl-5.1.6.RELEASE.jar
snakeyaml-1.23.jar
oas-validator-test-0.2.0.jar
spring-boot-starter-test-2.1.4.RELEASE.jar
spring-boot-test-2.1.4.RELEASE.jar
spring-boot-test-autoconfigure-2.1.4.RELEASE.jar
json-path-2.4.0.jar
json-smart-2.3.jar
accessors-smart-1.2.jar
junit-4.12.jar
assertj-core-3.11.1.jar
mockito-core-2.25.0.jar
byte-buddy-1.9.12.jar
byte-buddy-agent-1.9.12.jar
objenesis-2.6.jar
hamcrest-core-1.3.jar
hamcrest-library-1.3.jar
jsonassert-1.5.0.jar
android-json-0.0.20131108.vaadin1.jar
spring-test-5.1.6.RELEASE.jar
xmlunit-core-2.6.2.jar
oas-validator-style-0.2.0.jar
spring-context-5.1.6.RELEASE.jar
spring-aop-5.1.6.RELEASE.jar
spring-beans-5.1.6.RELEASE.jar
spring-expression-5.1.6.RELEASE.jar
oas-validator-compatibility-0.2.0.jar
oas-validator-compatibility-spring-0.2.0.jar
oas-generator-core-0.2.0.jar
swagger-models-2.0.10.jar
jackson-annotations-2.9.0.jar
swagger-annotations-2.0.10.jar
swagger-core-2.0.10.jar
jaxb-api-2.3.1.jar
javax.activation-api-1.2.0.jar
jackson-databind-2.9.8.jar
jackson-dataformat-yaml-2.9.8.jar
validation-api-2.0.1.Final.jar
asm-7.2.jar
oas-generator-servicecomb-0.2.0.jar
provider-rest-common-1.2.0.jar
common-rest-1.2.0.jar
provider-pojo-1.2.0.jar
java-chassis-core-1.2.0.jar
service-registry-1.2.0.jar
swagger-invocation-core-1.2.0.jar
swagger-generator-jaxrs-1.2.0.jar
oas-generator-jaxrs-0.2.0.jar
javax.ws.rs-api-2.1.jar
oas-generator-spring-0.2.0.jar
spring-web-5.1.6.RELEASE.jar
```