### PR TITLE
[SCB-1667] add addition properties that can be referenced by the must…

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -132,6 +132,13 @@ $ mvn clean install
             <!-- 服务id，默认值为artifactId的值 -->
             <serviceId>servicecomb-consumer</serviceId>
         </service>
+        <!-- 指定额外的属性值，这些属性值可以被mustach模板引用。仅为生成代码时使用，即goal为generate -->
+        <additionalProperties>
+            <prop1>value</prop1>
+            <prop2>value</prop2>
+            ...
+            <propN>value</propN>
+        </additionalProperties>
     </configuration>
 </plugin>
 ```
@@ -270,7 +277,9 @@ $ ./cli.sh  codegenerate -m ServiceComb -i swagger.yaml -o ./project -p SpringMV
 * --model-package : 指定生成项目的model package   
 例：--model-package com.demo.model
 * -t, --service-type : 指定生成的微服务项目的微服务类型。可选值为provider,consumer,all                  
-例：--service-type provider  
+例：--service-type provider
+* --properties : 指定额外的属性值，这些属性值可以被mustach模板引用
+例：--properties applicationId=app,providerServiceId=provider  
 
 #### 3.3.2 契约生成文档
 ```shell

--- a/README.md
+++ b/README.md
@@ -124,6 +124,13 @@ Configured in the pom file of the maven project
             <!-- Microservice project 'packageName',optional,the default is 'domain.orgnization.project.sample' -->
             <packageName>domain.orgnization.project.sample</packageName>
         </service>
+        <!-- Specify additional attribute values that can be referenced by the mustache template.Only used when plugin goal is generate -->
+        <additionalProperties>
+            <prop1>value</prop1>
+            <prop2>value</prop2>
+            ...
+            <propN>value</propN>
+        </additionalProperties>
     </configuration>
 </plugin>
 ```
@@ -263,6 +270,8 @@ e.g.：--api-package com.demo.api
 e.g.：--model-package com.demo.model
 * -t, --service-type : Specify microservice type of generated microservice project. optional value is provider,consumer,all               
 e.g.：--service-type provider  
+* --properties : Specify additional attribute values that can be referenced by the mustache template
+e.g.：--properties applicationId=app,providerServiceId=provider 
 
 #### 3.3.2 Service contract generation document
 ```shell

--- a/cli/src/main/java/org/apache/servicecomb/toolkit/cli/CodeGenerate.java
+++ b/cli/src/main/java/org/apache/servicecomb/toolkit/cli/CodeGenerate.java
@@ -27,10 +27,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 
-import org.apache.servicecomb.toolkit.GeneratorFactory;
 import org.apache.servicecomb.toolkit.CodeGenerator;
+import org.apache.servicecomb.toolkit.GeneratorFactory;
 import org.apache.servicecomb.toolkit.codegen.ProjectMetaConstant;
 import org.openapitools.codegen.config.CodegenConfigurator;
 import org.slf4j.Logger;
@@ -85,11 +87,30 @@ public class CodeGenerate implements Runnable {
       description = "microservice type of generated microservice project. optional value is provider,consumer,all")
   private String serviceType = "all";
 
+  @Option(
+      name = {"--properties"},
+      title = "additional properties",
+      description =
+          "usage: --properties name=value,name=value. These Properties can be referenced by the mustache templates."
+              + " You can specify one or more value")
+  private String properties;
+
   @Override
   public void run() {
 
     CodegenConfigurator configurator = new CodegenConfigurator();
+
     CodeGenerator codegenerator = GeneratorFactory.getGenerator(CodeGenerator.class, "default");
+
+    // add additional property
+    Optional.ofNullable(properties).ifPresent(properties ->
+        Arrays.stream(properties.split(",")).forEach(property -> {
+          String[] split = property.split("=");
+          if (split != null && split.length == 2) {
+            configurator.addAdditionalProperty(split[0], split[1]);
+          }
+        })
+    );
 
     configurator.setOutputDir(output)
         .setGroupId(groupId)

--- a/cli/src/test/java/org/apache/servicecomb/toolkit/cli/CliTest.java
+++ b/cli/src/test/java/org/apache/servicecomb/toolkit/cli/CliTest.java
@@ -52,7 +52,9 @@ public class CliTest {
             "-o",
             tempFile.toFile().getCanonicalPath(),
             "-p",
-            model
+            model,
+            "--properties",
+            "prop1=value,prop2=value"
         };
         Assert.assertTrue(!Files.exists(tempFile));
         ToolkitMain.main(args);

--- a/toolkit-maven-plugin/src/main/java/org/apache/servicecomb/toolkit/plugin/GenerateMojo.java
+++ b/toolkit-maven-plugin/src/main/java/org/apache/servicecomb/toolkit/plugin/GenerateMojo.java
@@ -72,6 +72,17 @@ public class GenerateMojo extends AbstractMojo {
   @Parameter
   private ServiceConfig service;
 
+  /**
+   * A map of additional properties that can be referenced by the mustache templates
+   * <additionalProperties>
+   *     <prop1>value</prop1>
+   *     <prop2>value</prop2>
+   *     ...
+   * </additionalProperties>
+   */
+  @Parameter
+  private Map<String, Object> additionalProperties;
+
   @Override
   public void execute() {
 
@@ -149,7 +160,7 @@ public class GenerateMojo extends AbstractMojo {
           outputDirectory + File.separator + "project" + File.separator;
       try {
         FileUtils.createDirectory(codeOutput);
-        Map<String, Object> externalConfig = new HashMap<>();
+        Map<String, Object> externalConfig = Optional.ofNullable(additionalProperties).orElse(new HashMap<>());
         externalConfig.put(GeneratorExternalConfigConstant.PROVIDER_PROJECT_NAME,
             project.getBasedir().getName() + providerProjectNameSuffix);
         externalConfig.put(GeneratorExternalConfigConstant.CONSUMER_PROJECT_NAME,

--- a/toolkit-maven-plugin/src/test/java/org/apache/servicecomb/toolkit/plugin/GenerateMojoTest.java
+++ b/toolkit-maven-plugin/src/test/java/org/apache/servicecomb/toolkit/plugin/GenerateMojoTest.java
@@ -27,14 +27,13 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import java.io.File;
-import java.lang.reflect.Field;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Objects;
 
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.testing.MojoRule;
 import org.apache.maven.plugin.testing.resources.TestResources;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.apache.servicecomb.toolkit.common.FileUtils;
 import org.junit.Rule;
@@ -99,6 +98,7 @@ public class GenerateMojoTest {
       testResourcesEx.setVariableValueToObject("contractFileType", "yaml");
       testResourcesEx.setVariableValueToObject("documentType", "html");
       testResourcesEx.setVariableValueToObject("service", new ServiceConfig());
+      testResourcesEx.setVariableValueToObject("additionalProperties", new HashMap<>());
 
       testResourcesEx.execute();
 


### PR DESCRIPTION
for two reason:

1. There are too many variables in the template, it would be too tedious if all of them are declared by member variables
2. Now there are two forms of cli and maven-plugin and some configuration about the template is out of sync