### PR TITLE
[SCB-1679] adjust main class package

### DIFF
--- a/cli/src/main/java/org/apache/servicecomb/toolkit/cli/CodeGenerate.java
+++ b/cli/src/main/java/org/apache/servicecomb/toolkit/cli/CodeGenerate.java
@@ -98,9 +98,14 @@ public class CodeGenerate implements Runnable {
   @Override
   public void run() {
 
-    CodegenConfigurator configurator = new CodegenConfigurator();
-
     CodeGenerator codegenerator = GeneratorFactory.getGenerator(CodeGenerator.class, "default");
+
+    if (codegenerator == null) {
+      LOGGER.warn("Not CodeGenerator found");
+      return;
+    }
+
+    CodegenConfigurator configurator = new CodegenConfigurator();
 
     // add additional property
     Optional.ofNullable(properties).ifPresent(properties ->
@@ -151,7 +156,7 @@ public class CodeGenerate implements Runnable {
           return;
         }
       } else {
-        configurator.setInputSpec(specFile);
+        configurator.setInputSpec(specFile).addAdditionalProperty("apiName", contractFile.getName().split("\\.")[0]);
         codegenerator.configure(Collections.singletonMap("configurator", configurator));
         codegenerator.generate();
       }

--- a/codegen/src/main/java/org/apache/servicecomb/toolkit/codegen/AbstractJavaCodegenExt.java
+++ b/codegen/src/main/java/org/apache/servicecomb/toolkit/codegen/AbstractJavaCodegenExt.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.languages.AbstractJavaCodegen;
@@ -46,7 +47,17 @@ public abstract class AbstractJavaCodegenExt extends AbstractJavaCodegen {
     apiPackage = groupId + "." + artifactId + ".api";
     modelPackage = groupId + "." + artifactId + ".model";
     mainClassPackage = groupId + "." + artifactId;
+  }
 
+  @Override
+  public void processOpts() {
+    super.processOpts();
+    if (StringUtils.isEmpty((String) additionalProperties.get("mainClassPackage"))) {
+      mainClassPackage = apiPackage.substring(0, apiPackage.lastIndexOf("."));
+      additionalProperties.put("mainClassPackage", mainClassPackage);
+    } else {
+      mainClassPackage = (String) additionalProperties.get("mainClassPackage");
+    }
   }
 
   @Override

--- a/codegen/src/main/java/org/apache/servicecomb/toolkit/codegen/ServiceCombCodegen.java
+++ b/codegen/src/main/java/org/apache/servicecomb/toolkit/codegen/ServiceCombCodegen.java
@@ -20,18 +20,15 @@ package org.apache.servicecomb.toolkit.codegen;
 import static org.openapitools.codegen.utils.StringUtils.camelize;
 
 import java.io.File;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.commons.lang3.StringUtils;
 import org.openapitools.codegen.CliOption;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.CodegenType;
-import org.openapitools.codegen.SupportingFile;
 import org.openapitools.codegen.languages.SpringCodegen;
 
 import io.swagger.codegen.mustache.CamelCaseLambda;
@@ -139,11 +136,6 @@ public class ServiceCombCodegen extends AbstractJavaCodegenExt {
 
     importMapping.put("OffsetDateTime", "java.time.OffsetDateTime");
     additionalProperties.put("dateLibrary", "java8");
-    if (StringUtils.isEmpty((String) additionalProperties.get("mainClassPackage"))) {
-      additionalProperties.put("mainClassPackage", mainClassPackage);
-    } else {
-      mainClassPackage = (String) additionalProperties.get("mainClassPackage");
-    }
     additionalProperties.put("camelcase", new CamelCaseLambda());
     additionalProperties.put("getGenericClassType", new GetGenericClassTypeLambda());
     additionalProperties.put("getRelativeBasePath", new GetRelativeBasePathLambda());

--- a/codegen/src/main/java/org/apache/servicecomb/toolkit/codegen/SpringCloudCodegen.java
+++ b/codegen/src/main/java/org/apache/servicecomb/toolkit/codegen/SpringCloudCodegen.java
@@ -64,11 +64,6 @@ public class SpringCloudCodegen extends AbstractJavaCodegenExt {
 
     importMapping.put("OffsetDateTime", "java.time.OffsetDateTime");
     additionalProperties.put("dateLibrary", "java8");
-    if (StringUtils.isEmpty((String) additionalProperties.get("mainClassPackage"))) {
-      additionalProperties.put("mainClassPackage", mainClassPackage);
-    } else {
-      mainClassPackage = (String) additionalProperties.get("mainClassPackage");
-    }
     additionalProperties.put("camelcase", new CamelCaseLambda());
     additionalProperties.put("apiTemplateFiles", apiTemplateFiles);
     additionalProperties.put("getGenericClassType", new GetGenericClassTypeLambda());

--- a/codegen/src/test/java/org/apache/servicecomb/toolkit/codegen/CustomPropertiesTest.java
+++ b/codegen/src/test/java/org/apache/servicecomb/toolkit/codegen/CustomPropertiesTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.servicecomb.toolkit.codegen;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CustomPropertiesTest {
+
+  @Test
+  public void customMainClassPackage() {
+
+    AbstractJavaCodegenExt javaCodegenExt = new AbstractJavaCodegenExt() {
+    };
+
+    javaCodegenExt.additionalProperties().put("mainClassPackage", "com.demo");
+    javaCodegenExt.processOpts();
+
+    Assert.assertEquals("com.demo", javaCodegenExt.mainClassPackage);
+  }
+
+  @Test
+  public void customApiPackage() {
+
+    AbstractJavaCodegenExt javaCodegenExt = new AbstractJavaCodegenExt() {
+    };
+
+    javaCodegenExt.additionalProperties().put("apiPackage", "com.demo.api");
+    javaCodegenExt.processOpts();
+
+    Assert.assertEquals("com.demo", javaCodegenExt.mainClassPackage);
+  }
+}


### PR DESCRIPTION
spring default scans the current package and all of its sub-packages.
so default main class package equals the parent package of api package