### PR TITLE
SCB-1701 Clean up the help document for CLI of toolkit

### DIFF
--- a/cli/src/main/java/org/apache/servicecomb/toolkit/cli/CheckCompatibility.java
+++ b/cli/src/main/java/org/apache/servicecomb/toolkit/cli/CheckCompatibility.java
@@ -20,7 +20,7 @@ package org.apache.servicecomb.toolkit.cli;
 import io.airlift.airline.Command;
 
 @Command(name = "checkcompatibility",
-    description = "Check compatibility for two OpenAPI v3 spec yamls, right one should be semantically compatible with left one")
+    description = "(Or cc for abbr). Check compatibility for two OpenAPI v3 spec yamls, right one should be semantically compatible with left one")
 public class CheckCompatibility extends CheckCompatibilityBase {
 
 }

--- a/cli/src/main/java/org/apache/servicecomb/toolkit/cli/CheckCompatibilityAbbr.java
+++ b/cli/src/main/java/org/apache/servicecomb/toolkit/cli/CheckCompatibilityAbbr.java
@@ -21,7 +21,8 @@ import io.airlift.airline.Command;
 
 @Command(name = "cc",
     description = "Check compatibility for two OpenAPI v3 spec yamls,"
-        + " right one should be semantically compatible with left one(abbr for checkcompatibility)")
+        + " right one should be semantically compatible with left one",
+    hidden = true)
 public class CheckCompatibilityAbbr extends CheckCompatibilityBase {
 
 }

--- a/cli/src/main/java/org/apache/servicecomb/toolkit/cli/CheckStyle.java
+++ b/cli/src/main/java/org/apache/servicecomb/toolkit/cli/CheckStyle.java
@@ -20,7 +20,7 @@ package org.apache.servicecomb.toolkit.cli;
 import io.airlift.airline.Command;
 
 @Command(name = "checkstyle",
-    description = "Check style for OpenAPI v3 spec yaml")
+    description = "(Or cs for abbr). Check style for OpenAPI v3 spec yaml.")
 public class CheckStyle extends CheckStyleBase {
 
 }

--- a/cli/src/main/java/org/apache/servicecomb/toolkit/cli/CheckStyleAbbr.java
+++ b/cli/src/main/java/org/apache/servicecomb/toolkit/cli/CheckStyleAbbr.java
@@ -20,7 +20,7 @@ package org.apache.servicecomb.toolkit.cli;
 import io.airlift.airline.Command;
 
 @Command(name = "cs",
-    description = "Check style for OpenAPI v3 spec yaml(abbr for checkstyle)")
+    description = "Check style for OpenAPI v3 spec yaml", hidden = true)
 public class CheckStyleAbbr extends CheckStyleBase {
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -625,6 +625,7 @@
             <exclude>**/*.md</exclude>
             <excldue>**/*.MD</excldue>
             <exclude>**/target/*</exclude>
+            <exclude>**/target/**/*</exclude>
             <!-- Skip the code style configuration file -->
             <exclude>**/etc/eclipse-java-google-style.xml</exclude>
             <exclude>**/etc/intellij-java-google-style.xml</exclude>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/SCB-1701

The help will looks like this:

```
usage: java -jar cli-0.2.0.jar <command> [<args>]The most commonly used java -jar cli-0.2.0.jar commands are:
    checkcompatibility   (Or cc for abbr). Check compatibility for two OpenAPI v3 spec yamls, right one should be semantically compatible with left one
    checkstyle           (Or cs for abbr). Check style for OpenAPI v3 spec yaml.
    codegenerate         Generate multiple models of microservice project by OpenAPI specification file
    docgenerate          Generate document by OpenAPI specification file
    help                 Display help informationSee 'java -jar cli-0.2.0.jar help <command>' for more information on a specific
command.
```